### PR TITLE
Add ESM build of delegate-it module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 index.js
+index.esm.js
 index.d.ts
 *.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
+delegate.es.js
 index.js
-index.esm.js
 index.d.ts
 *.map

--- a/index.ts
+++ b/index.ts
@@ -163,4 +163,4 @@ function delegate<TElement extends Element = Element, TEvent extends Event = Eve
 	});
 }
 
-export = delegate;
+export default delegate;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@typescript-eslint/parser": "^1.11.0",
 		"ava": "^2.1.0",
 		"eslint-config-xo-typescript": "^0.14.0",
+		"esm": "^3.2.25",
 		"jsdom": "^15.1.1",
 		"npm-run-all": "^4.1.5",
 		"sinon": "^7.3.2",
@@ -29,13 +30,13 @@
 		"xo": "*"
 	},
 	"scripts": {
-		"test": "tsc && xo && ava",
+		"test": "npm run build && xo && ava --require esm test.js && ava --require esm test-esm.js",
 		"prepare": "npm run build",
 		"build": "npm run build:esm && npm run build:cjs",
 		"build:cjs": "tsc",
 		"build:esm": "tsc -p tsconfig.esm.json && mv index.js index.esm.js",
 		"_watch-build": "tsc --watch",
-		"_watch-test": "ava --watch",
+		"_watch-test": "ava --watch --require esm",
 		"watch": "run-p --silent _watch-*"
 	},
 	"xo": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
 		"delegate",
 		"delegation"
 	],
-	"main": "index.js",
-	"module": "index.esm.js",
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.4.0",
 		"@typescript-eslint/eslint-plugin": "^1.6.0",
@@ -34,7 +32,7 @@
 		"prepare": "npm run build",
 		"build": "npm run build:esm && npm run build:cjs",
 		"build:cjs": "tsc",
-		"build:esm": "tsc -p tsconfig.esm.json && mv index.js index.esm.js",
+		"build:esm": "tsc -p tsconfig.esm.json && mv index.js delegate.es.js",
 		"_watch-build": "tsc --watch",
 		"_watch-test": "ava --watch --require esm",
 		"watch": "run-p --silent _watch-*"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,16 @@
 	"license": "MIT",
 	"files": [
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+		"index.esm.js"
 	],
 	"keywords": [
 		"event",
 		"delegate",
 		"delegation"
 	],
+	"main": "index.js",
+	"module": "index.esm.js",
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.4.0",
 		"@typescript-eslint/eslint-plugin": "^1.6.0",
@@ -27,8 +30,10 @@
 	},
 	"scripts": {
 		"test": "tsc && xo && ava",
-		"prepare": "tsc",
-		"build": "tsc",
+		"prepare": "npm run build",
+		"build": "npm run build:esm && npm run build:cjs",
+		"build:cjs": "tsc",
+		"build:esm": "tsc -p tsconfig.esm.json && mv index.js index.esm.js",
 		"_watch-build": "tsc --watch",
 		"_watch-test": "ava --watch",
 		"watch": "run-p --silent _watch-*"

--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,20 @@ npm install delegate-it
 
 ## Setup
 
+### CommonJS build
+
 ```js
 const delegate = require('delegate-it');
 ```
 
 ```js
 import delegate from 'delegate-it';
+```
+
+### ES module (for use with `esm` or similar)
+
+```js
+import delegate from 'delegate-it/delegate.es';
 ```
 
 ## Usage

--- a/suite.js
+++ b/suite.js
@@ -1,0 +1,143 @@
+/* eslint-disable ava/no-ignored-test-files */
+import test from 'ava';
+import sinon from 'sinon';
+import {JSDOM} from 'jsdom';
+
+/**
+ * We're dependency injecting "delegate" into this test suite
+ * so we can run the same tests against two different builds --
+ * a CommonJS build and an ESM build of `delegate`.
+ */
+const suite = ({delegate}) => {
+	const {window} = new JSDOM(`
+        <ul>
+            <li><a>Item 1</a></li>
+            <li><a>Item 2</a></li>
+            <li><a>Item 3</a></li>
+            <li><a>Item 4</a></li>
+            <li><a>Item 5</a></li>
+        </ul>
+    `);
+
+	global.Event = window.Event;
+	global.Element = window.Element;
+	global.document = window.document;
+
+	const container = window.document.querySelector('ul');
+	const anchor = window.document.querySelector('a');
+
+	test('should add an event listener', t => {
+		delegate(container, 'a', 'click', t.pass);
+		anchor.click();
+	});
+
+	test('should add an event listener only once', t => {
+		t.plan(2);
+
+		// Only deduplicates the `capture` flag
+		// https://github.com/bfred-it/delegate-it/pull/11#discussion_r285481625
+
+		// Capture: false
+		delegate(container, 'a', 'click', t.pass);
+		delegate(container, 'a', 'click', t.pass, {passive: true});
+		delegate(container, 'a', 'click', t.pass, {capture: false});
+
+		// Capture: true
+		delegate(container, 'a', 'click', t.pass, true);
+		delegate(container, 'a', 'click', t.pass, {capture: true});
+
+		anchor.click();
+	});
+
+	test('should remove an event listener', t => {
+		const spy = sinon.spy(container, 'removeEventListener');
+
+		const delegation = delegate(container, 'a', 'click', () => {});
+		delegation.destroy();
+
+		t.true(spy.calledOnce);
+		spy.restore();
+	});
+
+	test('should use `document` if the element is unspecified', t => {
+		delegate('a', 'click', t.pass);
+
+		anchor.click();
+	});
+
+	test('should remove an event listener the unspecified base (`document`)', t => {
+		const delegation = delegate('a', 'click', () => {});
+		const spy = sinon.spy(document, 'removeEventListener');
+
+		delegation.destroy();
+		t.true(spy.calledOnce);
+		spy.restore();
+	});
+
+	test('should add event listeners to all the elements in a base selector', t => {
+		const spy = sinon.spy();
+		delegate('li', 'a', 'click', spy);
+
+		const anchors = document.querySelectorAll('a');
+		anchors[0].click();
+		anchors[1].click();
+		t.true(spy.calledTwice);
+	});
+
+	test('should remove the event listeners from all the elements in a base selector', t => {
+		const items = document.querySelectorAll('li');
+		const spies = Array.prototype.map.call(items, li => {
+			return sinon.spy(li, 'removeEventListener');
+		});
+
+		const delegations = delegate('li', 'a', 'click', () => {});
+		delegations.forEach(delegation => {
+			delegation.destroy();
+		});
+
+		t.true(spies.every(spy => {
+			const success = spy.calledOnce;
+			spy.restore();
+			return success;
+		}));
+	});
+
+	test('should add event listeners to all the elements in a base array', t => {
+		const spy = sinon.spy();
+		const items = document.querySelectorAll('li');
+		delegate(items, 'a', 'click', spy);
+
+		const anchors = document.querySelectorAll('a');
+		anchors[0].click();
+		anchors[1].click();
+		t.true(spy.calledTwice);
+	});
+
+	test('should remove the event listeners from all the elements in a base array', t => {
+		const items = document.querySelectorAll('li');
+		const spies = Array.prototype.map.call(items, li => {
+			return sinon.spy(li, 'removeEventListener');
+		});
+
+		const delegations = delegate(items, 'a', 'click', () => {});
+		delegations.forEach(delegation => {
+			delegation.destroy();
+		});
+
+		t.true(spies.every(spy => {
+			const success = spy.calledOnce;
+			spy.restore();
+			return success;
+		}));
+	});
+
+	test('should not fire when the selector matches an ancestor of the base element', t => {
+		const spy = sinon.spy();
+		delegate(container, 'body', 'click', spy);
+
+		anchor.click();
+		t.true(spy.notCalled);
+	});
+};
+
+export default suite;

--- a/test-esm.js
+++ b/test-esm.js
@@ -1,4 +1,4 @@
 import suite from './suite';
-import delegate from './index.esm';
+import delegate from './delegate.es';
 
 suite({delegate});

--- a/test-esm.js
+++ b/test-esm.js
@@ -1,4 +1,4 @@
 import suite from './suite';
-import delegate from '.';
+import delegate from './index.esm';
 
 suite({delegate});

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"target": "es2015"
+	},
+	"files": [
+		"index.ts"
+	]
+}


### PR DESCRIPTION
Create ES module output for anyone who prefers that to CommonJS.

Refactored tests so they can run against both builds (CJS & ESM).

Updated build, test, and watch scripts accordingly.