### PR TITLE
Improve type inference for the listener callback

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,12 +83,12 @@ function safeClosest(event: Event, selector: string): Element | void {
  */
 function delegate<
 	TElement extends Element = Element,
-	TEvent extends Event = Event
+	TEventType extends EventType = EventType
 >(
 	base: EventTarget | Document | ArrayLike<Element> | string,
 	selector: string,
-	type: EventType,
-	callback: delegate.EventHandler<TEvent, TElement>,
+	type: TEventType,
+	callback: delegate.EventHandler<GlobalEventHandlersEventMap[TEventType], TElement>,
 	options?: boolean | AddEventListenerOptions
 ): delegate.Subscription {
 	// Handle Selector-based usage
@@ -101,7 +101,7 @@ function delegate<
 		const subscriptions = Array.prototype.map.call(
 			base,
 			(element: EventTarget) => {
-				return delegate<TElement, TEvent>(
+				return delegate<TElement, TEventType>(
 					element,
 					selector,
 					type,
@@ -127,7 +127,7 @@ function delegate<
 		const delegateTarget = safeClosest(event, selector);
 		if (delegateTarget) {
 			(event as any).delegateTarget = delegateTarget;
-			callback.call(baseElement, event as delegate.Event<TEvent, TElement>);
+			callback.call(baseElement, event as delegate.Event<GlobalEventHandlersEventMap[TEventType], TElement>);
 		}
 	};
 


### PR DESCRIPTION
Instead of using a generic Event type for the argument, the map of event types to the corresponding Event object types is used by the inference.

This is a BC break for projects specifying the generic types explicitly, as it changes the generic signature. For project relying on type inference, the inferred type becomes more specific.