### PR TITLE
Add support for events triggered on text nodes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -118,13 +118,10 @@ function delegate<
 	// Handle the regular Element usage
 	const capture = Boolean(typeof options === 'object' ? options.capture : options);
 	const listenerFn: EventListener = (event: Event): void => {
-		console.log(event);
-
 		const delegateTarget = safeClosest(event, selector);
 		if (delegateTarget) {
-			const delegateEvent = event as delegate.Event<TEvent, TElement>;
-			delegateEvent.delegateTarget = delegateTarget as TElement;
-			callback.call(baseElement, delegateEvent);
+			(event as any).delegateTarget = delegateTarget;
+			callback.call(baseElement, event as delegate.Event<TEvent, TElement>);
 		}
 	};
 

--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,7 @@ function safeClosest(event: Event, selector: string): Element | void {
 
 	const closest = target.closest(selector);
 
-	// Closest may match elements outside of the currentTarget so it needs to be limited to elements inside it
+	// `.closest()` may match ancestors of `currentTarget` but we only need its children
 	if (closest && event.currentTarget.contains(closest)) {
 		return closest;
 	}

--- a/index.ts
+++ b/index.ts
@@ -69,15 +69,12 @@ function safeClosest(event: Event, selector: string): Element | void {
 		target = target.parentElement;
 	}
 
-	if (!(target instanceof Element && event.currentTarget instanceof Element)) {
-		return;
-	}
-
-	const closest = target.closest(selector);
-
-	// `.closest()` may match ancestors of `currentTarget` but we only need its children
-	if (closest && event.currentTarget.contains(closest)) {
-		return closest;
+	if (target instanceof Element && event.currentTarget instanceof Element) {
+		// `.closest()` may match ancestors of `currentTarget` but we only need its children
+		const closest = target.closest(selector);
+		if (closest && event.currentTarget.contains(closest)) {
+			return closest;
+		}
 	}
 }
 

--- a/test.js
+++ b/test.js
@@ -16,6 +16,7 @@ const {window} = new JSDOM(`
     </ul>
 `);
 
+global.Text = window.Text;
 global.Event = window.Event;
 global.Element = window.Element;
 global.Document = window.Document;

--- a/test.js
+++ b/test.js
@@ -19,6 +19,7 @@ const {window} = new JSDOM(`
 global.Event = window.Event;
 global.Element = window.Element;
 global.Document = window.Document;
+global.MouseEvent = window.MouseEvent;
 global.document = window.document;
 const container = window.document.querySelector('ul');
 const anchor = window.document.querySelector('a');
@@ -44,6 +45,11 @@ test.serial('should add an event listener only once', t => {
 	delegate(container, 'a', 'click', t.pass, {capture: true});
 
 	anchor.click();
+});
+
+test.serial('should handle events on text nodes', t => {
+	delegate(container, 'a', 'click', t.pass);
+	anchor.firstChild.dispatchEvent(new MouseEvent('click', {bubbles: true}));
 });
 
 test.serial('should remove an event listener', t => {


### PR DESCRIPTION
This is currently failing because `selectstart` is dipatched on the text node, which doesn't have the `.closest` method.
```js
delegate(document, 'p', 'selectstart', console.log);
```

TypeScript had tried to warn me but I had half-`as`sed my way out of it 😅 