### PR TITLE
Add TSDoc for `options` parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,6 +82,7 @@ function safeClosest(event: Event, selector: string): Element | void {
 
 /**
  * Delegates event to a selector.
+ * @param options A boolean value setting options.capture or an options object of type AddEventListenerOptions
  */
 function delegate<
 	Selector extends string,


### PR DESCRIPTION
When consuming this in RGH, I had to look up what the `boolean` argument of the `options` parameter did, submitting this to help anyone else in the future.

Wasn't sure if you want this or if you do, if you want them all filled in, I felt the others were more self explanatory.