### PR TITLE
Don't return `AbortController`

### DIFF
--- a/test.js
+++ b/test.js
@@ -53,7 +53,8 @@ test.serial('should handle events on text nodes', t => {
 
 test.serial('should remove an event listener', t => {
 	const spy = sinon.spy();
-	const controller = delegate(container, 'a', 'click', spy);
+	const controller = new AbortController();
+	delegate(container, 'a', 'click', spy, {signal: controller.signal});
 	controller.abort();
 
 	const anchor = document.querySelector('a');
@@ -84,7 +85,8 @@ test.serial('should add event listeners to all the elements in a base selector',
 
 test.serial('should remove the event listeners from all the elements in a base selector', t => {
 	const spy = sinon.spy();
-	const controller = delegate('li', 'a', 'click', spy);
+	const controller = new AbortController();
+	delegate('li', 'a', 'click', spy, {signal: controller.signal});
 	controller.abort();
 
 	for (const anchor of document.querySelectorAll('a')) {
@@ -121,7 +123,8 @@ test.serial('should add event listeners to all the elements in a base array', t 
 test.serial('should remove the event listeners from all the elements in a base array', t => {
 	const spy = sinon.spy();
 	const items = document.querySelectorAll('li');
-	const controller = delegate(items, 'a', 'click', spy);
+	const controller = new AbortController();
+	delegate(items, 'a', 'click', spy, {signal: controller.signal});
 	controller.abort();
 
 	for (const anchor of document.querySelectorAll('a')) {


### PR DESCRIPTION
I think that accepting a signal _and_ returning a new controller is a bit confusing. I think it should match native events more closely: just accept a `signal`.

It's more verbose, but it pushes people to use and reuse signals instead:

```diff
- const controller = delegate(…);
+ const controller = new AbortController()
+ delegate(…, {signal: controller.signal})
  controller.abort()
```


```diff
- const controller1 = delegate(…);
- const controller2 = delegate(…);
- controller1.abort()
- controller2.abort()
+ const controller = new AbortController()
+ delegate(…, {signal: controller.signal})
+ delegate(…, {signal: controller.signal})
+ controller.abort()
```