### PR TITLE
Move `base` to options

### DIFF
--- a/delegate.test.ts
+++ b/delegate.test.ts
@@ -1,5 +1,5 @@
 import {test, vi, expect} from 'vitest';
-import {container, anchor} from './vitest.setup.js';
+import {base, anchor} from './vitest.setup.js';
 import delegate from './delegate.js';
 
 test('should add an event listener', () => {
@@ -36,15 +36,15 @@ test('should not add an event listener of the controller has already aborted', (
 
 test('should not fire when the selector matches an ancestor of the base element', () => {
 	const spy = vi.fn();
-	delegate('body', 'click', spy);
+	delegate('body', 'click', spy, {base});
 
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(0);
 });
 
 test('should not add an event listener when passed an already aborted signal', () => {
-	const spy = vi.spyOn(container, 'addEventListener');
-	delegate('a', 'click', () => ({}), {base: container, signal: AbortSignal.abort()});
+	const spy = vi.spyOn(base, 'addEventListener');
+	delegate('a', 'click', () => ({}), {base, signal: AbortSignal.abort()});
 
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(0);
@@ -52,9 +52,9 @@ test('should not add an event listener when passed an already aborted signal', (
 
 test('should call the listener once with the `once` option', () => {
 	const spy = vi.fn();
-	delegate('a', 'click', spy, {base: container, once: true});
+	delegate('a', 'click', spy, {base, once: true});
 
-	container.click();
+	base.click();
 	expect(spy).toHaveBeenCalledTimes(0); // It should not be called on the container
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(1); // It should be called on the delegate target
@@ -89,7 +89,7 @@ test('should deduplicate identical listeners added after `once:true`', () => {
 	delegate('a', 'click', spy, {once: true});
 	delegate('a', 'click', spy, {once: false});
 
-	container.click();
+	base.click();
 	expect(spy).toHaveBeenCalledTimes(0); // It should not be called on the container
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(1); // It should be called on the delegate target

--- a/delegate.test.ts
+++ b/delegate.test.ts
@@ -4,14 +4,14 @@ import delegate from './delegate.js';
 
 test('should add an event listener', () => {
 	const spy = vi.fn();
-	delegate(container, 'a', 'click', spy);
+	delegate('a', 'click', spy);
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(1);
 });
 
 test('should handle events on text nodes', () => {
 	const spy = vi.fn();
-	delegate(container, 'a', 'click', spy);
+	delegate('a', 'click', spy);
 	anchor.firstChild!.dispatchEvent(new MouseEvent('click', {bubbles: true}));
 	expect(spy).toHaveBeenCalledTimes(1);
 });
@@ -19,7 +19,7 @@ test('should handle events on text nodes', () => {
 test('should remove an event listener', () => {
 	const spy = vi.fn();
 	const controller = new AbortController();
-	delegate(container, 'a', 'click', spy, {signal: controller.signal});
+	delegate('a', 'click', spy, {signal: controller.signal});
 	controller.abort();
 
 	anchor.click();
@@ -28,7 +28,7 @@ test('should remove an event listener', () => {
 
 test('should not add an event listener of the controller has already aborted', () => {
 	const spy = vi.fn();
-	delegate(container, 'a', 'click', spy, {signal: AbortSignal.abort()});
+	delegate('a', 'click', spy, {signal: AbortSignal.abort()});
 
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(0);
@@ -36,7 +36,7 @@ test('should not add an event listener of the controller has already aborted', (
 
 test('should not fire when the selector matches an ancestor of the base element', () => {
 	const spy = vi.fn();
-	delegate(container, 'body', 'click', spy);
+	delegate('body', 'click', spy);
 
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(0);
@@ -44,7 +44,7 @@ test('should not fire when the selector matches an ancestor of the base element'
 
 test('should not add an event listener when passed an already aborted signal', () => {
 	const spy = vi.spyOn(container, 'addEventListener');
-	delegate(container, 'a', 'click', () => ({}), {signal: AbortSignal.abort()});
+	delegate('a', 'click', () => ({}), {base: container, signal: AbortSignal.abort()});
 
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(0);
@@ -52,7 +52,7 @@ test('should not add an event listener when passed an already aborted signal', (
 
 test('should call the listener once with the `once` option', () => {
 	const spy = vi.fn();
-	delegate(container, 'a', 'click', spy, {once: true});
+	delegate('a', 'click', spy, {base: container, once: true});
 
 	container.click();
 	expect(spy).toHaveBeenCalledTimes(0); // It should not be called on the container
@@ -69,16 +69,16 @@ test('should add a specific event listener only once', () => {
 	// https://github.com/fregante/delegate-it/pull/11#discussion_r285481625
 
 	// Capture: false
-	delegate(container, 'a', 'click', spy);
-	delegate(container, 'a', 'click', spy, {passive: true});
-	delegate(container, 'a', 'click', spy, {capture: false});
+	delegate('a', 'click', spy);
+	delegate('a', 'click', spy, {passive: true});
+	delegate('a', 'click', spy, {capture: false});
 
 	// Capture: true
-	delegate(container, 'a', 'click', spy, {capture: true});
+	delegate('a', 'click', spy, {capture: true});
 
 	// Once
-	delegate(container, 'a', 'click', spy, {once: true});
-	delegate(container, 'a', 'click', spy, {once: false});
+	delegate('a', 'click', spy, {once: true});
+	delegate('a', 'click', spy, {once: false});
 
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(2);
@@ -86,8 +86,8 @@ test('should add a specific event listener only once', () => {
 
 test('should deduplicate identical listeners added after `once:true`', () => {
 	const spy = vi.fn();
-	delegate(container, 'a', 'click', spy, {once: true});
-	delegate(container, 'a', 'click', spy, {once: false});
+	delegate('a', 'click', spy, {once: true});
+	delegate('a', 'click', spy, {once: false});
 
 	container.click();
 	expect(spy).toHaveBeenCalledTimes(0); // It should not be called on the container

--- a/delegate.ts
+++ b/delegate.ts
@@ -1,6 +1,6 @@
 import type {ParseSelector} from 'typed-query-selector/parser.d.js';
 
-export type DelegateOptions = AddEventListenerOptions;
+export type DelegateOptions = AddEventListenerOptions & {base?: EventTarget};
 export type EventType = keyof GlobalEventHandlersEventMap;
 
 export type DelegateEventHandler<
@@ -73,7 +73,6 @@ function delegate<
 	TElement extends Element = ParseSelector<Selector, HTMLElement>,
 	TEventType extends EventType = EventType,
 >(
-	base: EventTarget,
 	selector: Selector,
 	type: TEventType,
 	callback: DelegateEventHandler<GlobalEventHandlersEventMap[TEventType], TElement>,
@@ -84,7 +83,6 @@ function delegate<
 	TElement extends Element = HTMLElement,
 	TEventType extends EventType = EventType,
 >(
-	base: EventTarget,
 	selector: string,
 	type: TEventType,
 	callback: DelegateEventHandler<GlobalEventHandlersEventMap[TEventType], TElement>,
@@ -96,13 +94,12 @@ function delegate<
 	TElement extends Element,
 	TEventType extends EventType = EventType,
 >(
-	base: EventTarget,
 	selector: string,
 	type: TEventType,
 	callback: DelegateEventHandler<GlobalEventHandlersEventMap[TEventType], TElement>,
 	options: DelegateOptions = {},
 ): void {
-	const {signal} = options;
+	const {signal, base = document} = options;
 
 	if (signal?.aborted) {
 		return;

--- a/one-event.test.ts
+++ b/one-event.test.ts
@@ -1,9 +1,9 @@
 import {test, expect} from 'vitest';
-import {container, anchor} from './vitest.setup.js';
+import {anchor} from './vitest.setup.js';
 import oneEvent from './one-event.js';
 
 test('should resolve after one event', async t => {
-	const promise = oneEvent(container, 'a', 'click');
+	const promise = oneEvent('a', 'click');
 	anchor.click();
 	const event = await promise;
 	expect(event).toBeInstanceOf(MouseEvent);
@@ -11,7 +11,7 @@ test('should resolve after one event', async t => {
 
 test('should resolve with `undefined` after it’s aborted', async t => {
 	const controller = new AbortController();
-	const promise = oneEvent(container, 'a', 'click', {signal: controller.signal});
+	const promise = oneEvent('a', 'click', {signal: controller.signal});
 	controller.abort();
 
 	const event = await promise;
@@ -19,7 +19,7 @@ test('should resolve with `undefined` after it’s aborted', async t => {
 });
 
 test('should resolve with `undefined` if the signal has already aborted', async t => {
-	const promise = oneEvent(container, 'a', 'click', {signal: AbortSignal.abort()});
+	const promise = oneEvent('a', 'click', {signal: AbortSignal.abort()});
 	const event = await promise;
 	expect(event).toBeUndefined();
 });

--- a/one-event.ts
+++ b/one-event.ts
@@ -13,7 +13,6 @@ async function oneEvent<
 	TElement extends Element = ParseSelector<Selector, HTMLElement>,
 	TEventType extends EventType = EventType,
 >(
-	base: EventTarget,
 	selector: Selector,
 	type: TEventType,
 	options?: DelegateOptions
@@ -23,7 +22,6 @@ async function oneEvent<
 	TElement extends Element = HTMLElement,
 	TEventType extends EventType = EventType,
 >(
-	base: EventTarget,
 	selector: string,
 	type: TEventType,
 	options?: DelegateOptions
@@ -34,7 +32,6 @@ async function oneEvent<
 	TElement extends Element,
 	TEventType extends EventType = EventType,
 >(
-	base: EventTarget,
 	selector: string,
 	type: TEventType,
 	options: DelegateOptions = {},
@@ -51,7 +48,6 @@ async function oneEvent<
 		});
 
 		delegate(
-			base,
 			selector,
 			type,
 			// @ts-expect-error Seems to work fine

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ import delegate from 'delegate-it';
 ### Add event delegation
 
 ```js
-delegate(document, '.btn', 'click', event => {
+delegate('.btn', 'click', event => {
 	console.log(event.delegateTarget);
 });
 ```
@@ -38,10 +38,22 @@ delegate(document, '.btn', 'click', event => {
 ### With listener options
 
 ```js
-delegate(document, '.btn', 'click', event => {
+delegate('.btn', 'click', event => {
 	console.log(event.delegateTarget);
 }, {
 	capture: true
+});
+```
+
+### On a custom base
+
+Use this option if you don't want to have a global listener attached on `html`, it improves performance:
+
+```js
+delegate('.btn', 'click', event => {
+	console.log(event.delegateTarget);
+}, {
+	base: document.querySelector('main')
 });
 ```
 
@@ -49,7 +61,7 @@ delegate(document, '.btn', 'click', event => {
 
 ```js
 const controller = new AbortController();
-delegate(document, '.btn', 'click', event => {
+delegate('.btn', 'click', event => {
 	console.log(event.delegateTarget);
 }, {
 	signal: controller.signal,
@@ -61,7 +73,7 @@ controller.abort();
 ### Listen to one event only
 
 ```js
-delegate(document, '.btn', 'click', event => {
+delegate('.btn', 'click', event => {
 	console.log('This will only be called once');
 }, {
 	once: true
@@ -73,7 +85,7 @@ delegate(document, '.btn', 'click', event => {
 ```js
 import {oneEvent} from 'delegate-it';
 
-await oneEvent(document, '.btn', 'click');
+await oneEvent('.btn', 'click');
 console.log('The body was clicked');
 ```
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -17,5 +17,5 @@ global.Document = window.Document;
 global.MouseEvent = window.MouseEvent;
 global.AbortController = window.AbortController;
 global.document = window.document;
-export const container = window.document.querySelector('ul')!;
+export const base = window.document.querySelector('ul')!;
 export const anchor = window.document.querySelector('a')!;


### PR DESCRIPTION
Let's be honest, no one is using a custom base just because it's the first option. 

This change reduces the function parameters to 4, which is already high.

Reverts:

- #15 