### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: npm install
-      - run: npm run build
       - run: npx vitest

--- a/delegate.ts
+++ b/delegate.ts
@@ -113,13 +113,13 @@ function delegate<
 
 	// Handle the regular Element usage
 	const capture = Boolean(typeof options === 'object' ? options.capture : options);
-	const listenerFn = (event: Event): void => {
+	const listenerFunction = (event: Event): void => {
 		const delegateTarget = safeClosest(event, selector);
 		if (delegateTarget) {
 			const delegateEvent = Object.assign(event, {delegateTarget});
 			callback.call(baseElement, delegateEvent as DelegateEvent<GlobalEventHandlersEventMap[TEventType], TElement>);
 			if (once) {
-				baseElement.removeEventListener(type, listenerFn, nativeListenerOptions);
+				baseElement.removeEventListener(type, listenerFunction, nativeListenerOptions);
 				editLedger(false, baseElement, callback, setup);
 			}
 		}
@@ -128,7 +128,7 @@ function delegate<
 	const setup = JSON.stringify({selector, type, capture});
 	const isAlreadyListening = editLedger(true, baseElement, callback, setup);
 	if (!isAlreadyListening) {
-		baseElement.addEventListener(type, listenerFn, nativeListenerOptions);
+		baseElement.addEventListener(type, listenerFunction, nativeListenerOptions);
 	}
 
 	signal?.addEventListener('abort', () => {

--- a/one-event.ts
+++ b/one-event.ts
@@ -50,7 +50,6 @@ async function oneEvent<
 		delegate(
 			selector,
 			type,
-			// @ts-expect-error Seems to work fine
 			resolve,
 			options,
 		);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		}
 	},
 	"dependencies": {
-		"typed-query-selector": "^2.11.1"
+		"typed-query-selector": "^2.11.2"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
 		}
 	},
 	"dependencies": {
-		"typed-query-selector": "^2.10.0"
+		"typed-query-selector": "^2.11.1"
 	},
 	"devDependencies": {
-		"@sindresorhus/tsconfig": "^3.0.1",
-		"@types/jsdom": "^21.1.1",
-		"jsdom": "^21.1.1",
-		"typescript": "^5.0.4",
-		"vitest": "^0.30.1",
-		"xo": "^0.54.1"
+		"@sindresorhus/tsconfig": "^5.0.0",
+		"@types/jsdom": "^21.1.6",
+		"jsdom": "^24.0.0",
+		"typescript": "^5.4.2",
+		"vitest": "^1.3.1",
+		"xo": "^0.58.0"
 	}
 }


### PR DESCRIPTION
- Will close #50 

Blocked by https://github.com/g-plane/typed-query-selector/commit/ed964d1f1773905b64f99a68d4b8e54b4a326fe9#r139690533

```yml
one-event.ts:13:29 - error TS2344: Type 'ParseSelector<Selector, HTMLElement>' does not satisfy the constraint 'Element'.
  Type 'HTMLElement | ExpandAnd<string & ParseSelectorToTagNames<Selector>, HTMLElement>' is not assignable to type 'Element'.
    Type 'ExpandAnd<string & ParseSelectorToTagNames<Selector>, HTMLElement>' is not assignable to type 'Element'.
      Type 'HTMLElement | ExpandAndInner<string & ParseSelectorToTagNames<Selector>, HTMLElement, unknown>' is not assignable to type 'Element'.
        Type 'ExpandAndInner<string & ParseSelectorToTagNames<Selector>, HTMLElement, unknown>' is not assignable to type 'Element'.
          Type 'unknown' is not assignable to type 'Element'.

  TElement extends Element = ParseSelector<Selector, HTMLElement>,
```